### PR TITLE
Allow configurable fastcgi_param REQUEST_URI and DOCUMENT_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Supported tags and respective `Dockerfile` links:
 | `NGINX_ERROR_404_URI`                                |                             |                                     |
 | `NGINX_ERROR_LOG_LEVEL`                              | `error`                     |                                     |
 | `NGINX_ERROR_MESSAGE_50x`                            |                             |                                     |
-| `NGINX_FASTCGI_REQUEST_URI`                          | `$request_uri`              | For PHP-based presets only          |
-| `NGINX_FASTCGI_DOCUMENT_URI`                         | `$document_uri`             | For PHP-based presets only          |
+| `NGINX_FASTCGI_PARAM_REQUEST_URI`                          | `$request_uri`              | For PHP-based presets only          |
+| `NGINX_FASTCGI_PARAM_DOCUMENT_URI`                         | `$document_uri`             | For PHP-based presets only          |
 | `NGINX_FASTCGI_BUFFER_SIZE`                          | `32k`                       | For PHP-based presets only          |
 | `NGINX_FASTCGI_BUFFERS`                              | `16 32k`                    | For PHP-based presets only          |
 | `NGINX_FASTCGI_INDEX`                                | `index.php`                 | For PHP-based presets only          |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Supported tags and respective `Dockerfile` links:
 | `NGINX_ERROR_404_URI`                                |                             |                                     |
 | `NGINX_ERROR_LOG_LEVEL`                              | `error`                     |                                     |
 | `NGINX_ERROR_MESSAGE_50x`                            |                             |                                     |
+| `NGINX_FASTCGI_REQUEST_URI`                          | `$request_uri`              | For PHP-based presets only          |
+| `NGINX_FASTCGI_DOCUMENT_URI`                         | `$document_uri`             | For PHP-based presets only          |
 | `NGINX_FASTCGI_BUFFER_SIZE`                          | `32k`                       | For PHP-based presets only          |
 | `NGINX_FASTCGI_BUFFERS`                              | `16 32k`                    | For PHP-based presets only          |
 | `NGINX_FASTCGI_INDEX`                                | `index.php`                 | For PHP-based presets only          |

--- a/templates/includes/fastcgi.conf.tmpl
+++ b/templates/includes/fastcgi.conf.tmpl
@@ -2,8 +2,8 @@ fastcgi_param REQUEST_METHOD $request_method;
 fastcgi_param CONTENT_TYPE $content_type if_not_empty;
 fastcgi_param CONTENT_LENGTH $content_length;
 
-fastcgi_param REQUEST_URI $request_uri;
-fastcgi_param DOCUMENT_URI $document_uri;
+fastcgi_param REQUEST_URI {{ getenv "NGINX_FASTCGI_REQUEST_URI" "$request_uri" }};
+fastcgi_param DOCUMENT_URI {{ getenv "NGINX_FASTCGI_DOCUMENT_URI" "$document_uri" }};
 fastcgi_param DOCUMENT_ROOT $document_root;
 fastcgi_param SERVER_PROTOCOL $server_protocol;
 

--- a/templates/includes/fastcgi.conf.tmpl
+++ b/templates/includes/fastcgi.conf.tmpl
@@ -2,8 +2,8 @@ fastcgi_param REQUEST_METHOD $request_method;
 fastcgi_param CONTENT_TYPE $content_type if_not_empty;
 fastcgi_param CONTENT_LENGTH $content_length;
 
-fastcgi_param REQUEST_URI {{ getenv "NGINX_FASTCGI_REQUEST_URI" "$request_uri" }};
-fastcgi_param DOCUMENT_URI {{ getenv "NGINX_FASTCGI_DOCUMENT_URI" "$document_uri" }};
+fastcgi_param REQUEST_URI {{ getenv "NGINX_FASTCGI_PARAM_REQUEST_URI" "$request_uri" }};
+fastcgi_param DOCUMENT_URI {{ getenv "NGINX_FASTCGI_PARAM_DOCUMENT_URI" "$document_uri" }};
 fastcgi_param DOCUMENT_ROOT $document_root;
 fastcgi_param SERVER_PROTOCOL $server_protocol;
 


### PR DESCRIPTION
Hello, I'd like to add the option to allow configurable `REQUEST_URI` and `DOCUMENT_URI`.

The reason is that some PHP applications use `$_SERVER['REQUEST_URI']` to match the current request, however in *nginx* the variable `$request_uri` contains the initial unmodified request URI, while `$document_uri` contains the normalised and final URI, allowing internal redirects and alterations.

Our specific problem comes on a Drupal 8 App where we use an internal redirect _(without returning a 301 to the user)_, which works fine on the `nginx` part, however as mentioned above Drupal uses the server variable `REQUEST_URI` to match the path and as I pointed out this variable is passed to php-fpm as `fastcgi_param REQUEST_URI $request_uri;` which causes the issue indicated in the summary. 

The simplest solution is to use `fastcgi_param REQUEST_URI $document_uri`, at first sight this might look wrong, but considering *Drupal* is dealing with `$_SERVER['REQUEST_URI']` the same as *nginx* is handling `$document_uri` I believe this is actually a correct usage.

In any case, with this PR we leave it by default to the current behaviour and allow users to configure this behaviour via ENV variables.


Just a bit of context to our specific issue:
`http://example-alpha.com/foobar` should be serving the page: `http://example.com/group/1/foobar`
while `http://another-site.com/foobar` should be serving the page `http://example.com/group/2/foobar`

We could of course achieve this using nginx as reverse proxy, but this creates some non necessary overhead _(For example in the Wodby hosted setup we would need to pass the request again through the whole dns->http->edge->nginx stack)_ and since the only change is the url, would be nice to have this simply a config in one app, especially considering the config itself it's rather simple and just a few lines.