### PR TITLE
Make extra config be able to work without defaults.

### DIFF
--- a/templates/includes/defaults.conf.tmpl
+++ b/templates/includes/defaults.conf.tmpl
@@ -73,7 +73,3 @@ error_page 403 {{ getenv "NGINX_ERROR_403_URI" }};
 {{ if getenv "NGINX_ERROR_404_URI" }}
 error_page 404 {{ getenv "NGINX_ERROR_404_URI" }};
 {{ end }}
-
-{{ if getenv "NGINX_SERVER_EXTRA_CONF_FILEPATH" }}
-include {{ getenv "NGINX_SERVER_EXTRA_CONF_FILEPATH" }};
-{{ end }}

--- a/templates/vhost.conf.tmpl
+++ b/templates/vhost.conf.tmpl
@@ -18,4 +18,8 @@ server {
     {{ if not (getenv "NGINX_VHOST_NO_DEFAULTS") }}
     include defaults.conf;
     {{ end }}
+
+    {{ if getenv "NGINX_SERVER_EXTRA_CONF_FILEPATH" }}
+    include {{ getenv "NGINX_SERVER_EXTRA_CONF_FILEPATH" }};
+    {{ end }}
 }


### PR DESCRIPTION
Hi guys

I run into a very interesting issue with `wodby/nginx`. We want to use the module https://www.drupal.org/project/robotstxt, which requires nginx location `/robots.txt` to pass to `@drupal`, but it’s hard coded here: https://github.com/wodby/nginx/blob/master/templates/includes/defaults.conf.tmpl#L18

I could have disabled defaults by setting `$NGINX_VHOST_NO_DEFAULTS`, but then it does not include my custom config, as here’s the last lines of default template: https://github.com/wodby/nginx/blob/master/templates/includes/defaults.conf.tmpl#L77

So it is sort of mutual dependency with no way out. I've drafted a patch which resolves this dependency. 