### PR TITLE
Increase default NGINX_STATIC_EXPIRES to 1 year.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Supported tags and respective `Dockerfile` links:
 | `NGINX_SET_REAL_IP_FROM`                             |                             |                                     |
 | `NGINX_STATIC_404_TRY_INDEX`                         |                             |                                     |
 | `NGINX_STATIC_ACCESS_LOG`                            | `off`                       |                                     |
-| `NGINX_STATIC_EXPIRES`                               | `7d`                        |                                     |
+| `NGINX_STATIC_EXPIRES`                               | `1y`                        |                                     |
 | `NGINX_STATIC_MP4_BUFFER_SIZE`                       | `1M`                        |                                     |
 | `NGINX_STATIC_MP4_MAX_BUFFER_SIZE`                   | `5M`                        |                                     |
 | `NGINX_STATIC_OPEN_FILE_CACHE_ERRORS`                | `on`                        |                                     |

--- a/templates/includes/defaults.conf.tmpl
+++ b/templates/includes/defaults.conf.tmpl
@@ -9,7 +9,7 @@ location ^~ /.well-known/ {
 }
 
 location = /favicon.ico {
-    expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+    expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
     try_files /favicon.ico @empty;
     log_not_found off;
     access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
@@ -22,7 +22,7 @@ location = /robots.txt {
 }
 
 location @empty {
-    expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+    expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
     empty_gif;
 }
 

--- a/templates/presets/drupal6.conf.tmpl
+++ b/templates/presets/drupal6.conf.tmpl
@@ -31,19 +31,19 @@ location / {
 
     location ~* /imagecache/ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         try_files $uri @drupal;
     }
 
     location ~* /files/styles/ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         try_files $uri @drupal;
     }
 
     location ~* /sites/.+/files/.+\.txt {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
         open_file_cache {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE" "max=1000 inactive=30s" }};
         open_file_cache_valid {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE_VALID" "30s" }};
@@ -97,7 +97,7 @@ location / {
     location ~* ^.+\.(?:{{ $static }})$ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
 
         add_header Pragma "cache";
         add_header Cache-Control "public";

--- a/templates/presets/drupal7.conf.tmpl
+++ b/templates/presets/drupal7.conf.tmpl
@@ -33,13 +33,13 @@ location / {
 
     location ~* /files/styles/ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         try_files $uri @drupal;
     }
 
     location ~* /sites/.+/files/.+\.txt {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
         open_file_cache {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE" "max=1000 inactive=30s" }};
         open_file_cache_valid {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE_VALID" "30s" }};
@@ -93,7 +93,7 @@ location / {
     location ~* ^.+\.(?:{{ $static }})$ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
 
         add_header Pragma "cache";
         add_header Cache-Control "public";

--- a/templates/presets/drupal8.conf.tmpl
+++ b/templates/presets/drupal8.conf.tmpl
@@ -33,13 +33,13 @@ location / {
 
     location ~* /files/styles/ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         try_files $uri @drupal;
     }
 
     location ~* /sites/.+/files/.+\.txt {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
         open_file_cache {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE" "max=1000 inactive=30s" }};
         open_file_cache_valid {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE_VALID" "30s" }};
@@ -93,7 +93,7 @@ location / {
     location ~* ^.+\.(?:{{ $static }})$ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
 
         add_header Pragma "cache";
         add_header Cache-Control "public";

--- a/templates/presets/html.conf.tmpl
+++ b/templates/presets/html.conf.tmpl
@@ -5,7 +5,7 @@ location / {
     location ~* ^.+\.(?:{{ $static }})$ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
 
         add_header Pragma "cache";
         add_header Cache-Control "public";

--- a/templates/presets/php.conf.tmpl
+++ b/templates/presets/php.conf.tmpl
@@ -9,7 +9,7 @@ location / {
     location ~* ^.+\.(?:{{ $static }})$ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
 
         add_header Pragma "cache";
         add_header Cache-Control "public";

--- a/templates/presets/wordpress.conf.tmpl
+++ b/templates/presets/wordpress.conf.tmpl
@@ -18,7 +18,7 @@ location / {
 
     location ~* /wp-content/uploads/.+\.txt {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
         open_file_cache {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE" "max=1000 inactive=30s" }};
         open_file_cache_valid {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE_VALID" "30s" }};
@@ -37,7 +37,7 @@ location / {
     location ~* ^.+\.(?:{{ $static }})$ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
         tcp_nodelay {{ getenv "NGINX_STATIC_TCP_NODELAY" "off" }};
-        expires {{ getenv "NGINX_STATIC_EXPIRES" "7d" }};
+        expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
 
         add_header Pragma "cache";
         add_header Cache-Control "public";


### PR DESCRIPTION
As we already set the value to be high enough which makes it so that
the content won't be loaded between requests, we might as well set it
to very high as suggested by Google pagespeed insights.

Ref. https://developers.google.com/web/tools/lighthouse/audits/cache-policy