### PR TITLE
Add rebuild.php to Drupal 8 preset.

### DIFF
--- a/templates/presets/drupal8.conf.tmpl
+++ b/templates/presets/drupal8.conf.tmpl
@@ -142,6 +142,10 @@ location = /core/install.php {
     fastcgi_pass php;
 }
 
+location = /core/rebuild.php {
+    fastcgi_pass php;
+}
+
 location ~* ^/core/authorize.php {
     include fastcgi.conf;
     fastcgi_param QUERY_STRING $args;


### PR DESCRIPTION
Currently core/rebuild.php is not accessible using this nginx image. Here is a simple fix.

More on the rebuild.php script: https://api.drupal.org/api/drupal/core%21rebuild.php/8.2.x