### PR TITLE
Added Nginx status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Supported tags and respective `Dockerfile` links:
 | `NGINX_STATIC_OPEN_FILE_CACHE_MIN_USES`              | `2`                         |                                     |
 | `NGINX_STATIC_OPEN_FILE_CACHE_VALID`                 | `30s`                       |                                     |
 | `NGINX_STATIC_OPEN_FILE_CACHE`                       | `max=1000 inactive=30s`     |                                     |
+| `NGINX_STATUS_ALLOW_FROM`                            |                             | e.g. `172.18.0.0/16`                |
+| `NGINX_STATUS_ENABLED`                               | `off`                       |                                     |
 | `NGINX_TCP_NODELAY`                                  | `on`                        |                                     |
 | `NGINX_TCP_NOPUSH`                                   | `on`                        |                                     |
 | `NGINX_TRACK_UPLOADS`                                | `uploads 60s`               |                                     |

--- a/templates/includes/defaults.conf.tmpl
+++ b/templates/includes/defaults.conf.tmpl
@@ -49,6 +49,17 @@ location ~ ^/\.healthz$ {
     return 204;
 }
 
+{{ if getenv "NGINX_STATUS_ENABLED" }}
+location = /.statusz {
+    stub_status;
+    allow 127.0.0.1;
+    {{ if getenv "NGINX_STATUS_ALLOW_FROM" }}
+    allow {{ getenv "NGINX_STATUS_ALLOW_FROM" }};
+    {{ end }}
+    deny all;
+}
+{{ end }}
+
 {{ if getenv "NGINX_PAGESPEED_ENABLED" }}
 {{ $pagespeed := (getenv "NGINX_PAGESPEED" "on") }}
 {{ if (eq $pagespeed "on") }}


### PR DESCRIPTION
Nginx status endpoint `/.statusz` disabled by default. Once enabled via `NGINX_STATUS_ENABLED` it is limited for requests from 127.0.0.1 only. Could be allowed for extra IP range via `NGINX_STATUS_ALLOW_FROM`, e.g. `172.18.0.0/16`.