### PR TITLE
Fix custom preset upstream.conf creation

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -57,7 +57,7 @@ process_templates() {
 
             _gotpl "includes/upstream.http-proxy.conf.tmpl" "/etc/nginx/upstream.conf"
         elif [[ -f "/etc/gotpl/includes/upstream.${NGINX_VHOST_PRESET}.conf.tmpl" ]]; then
-            _gotpl "includes/upstream.${NGINX_VHOST_PRESET}.conf.tmpl" "/etc/nginx/upstream.conf"
+            _gotpl "/etc/gotpl/includes/upstream.${NGINX_VHOST_PRESET}.conf.tmpl" "/etc/nginx/upstream.conf"
         else
             touch /etc/nginx/upstream.conf
         fi


### PR DESCRIPTION
The file _entrypoint.sh_ does not use the proper path to generate the custom upstream configuration file.