### PR TITLE
Allow more than one set_real_ip_from rule in case of multiple reverse proxy addresses/ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ All images built for `linux/amd64` and `linux/arm64`
 | `NGINX_SERVER_ROOT`                                  | `/var/www/html`             |                                     |
 | `NGINX_SERVER_TOKENS`                                | `off`                       |                                     |
 | `NGINX_SET_REAL_IP_FROM`                             |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_2`                           |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_3`                           |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_4`                           |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_5`                           |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_6`                           |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_7`                           |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_8`                           |                             |                                     |
+| `NGINX_SET_REAL_IP_FROM_9`                           |                             |                                     |
 | `NGINX_STATIC_404_TRY_INDEX`                         |                             |                                     |
 | `NGINX_STATIC_ACCESS_LOG`                            | `off`                       |                                     |
 | `NGINX_STATIC_EXPIRES`                               | `1y`                        |                                     |

--- a/templates/nginx.conf.tmpl
+++ b/templates/nginx.conf.tmpl
@@ -117,6 +117,30 @@ http {
     {{ if getenv "NGINX_SET_REAL_IP_FROM" }}
     set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM" }};
     {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_2" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_2" }};
+    {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_3" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_3" }};
+    {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_4" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_4" }};
+    {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_5" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_5" }};
+    {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_6" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_6" }};
+    {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_7" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_7" }};
+    {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_8" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_8" }};
+    {{ end }}
+    {{ if getenv "NGINX_SET_REAL_IP_FROM_9" }}
+    set_real_ip_from {{ getenv "NGINX_SET_REAL_IP_FROM_9" }};
+    {{ end }}
 
     real_ip_header {{ getenv "NGINX_REAL_IP_HEADER" "X-Real-IP" }};
     real_ip_recursive {{ getenv "NGINX_REAL_IP_RECURSIVE" "off" }};


### PR DESCRIPTION
The [ngx_http_realip_module](http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from) module does not allow multiple addresses or ranges in one rule.

