### PR TITLE
Add Docker build arguments for wodby UID and GID

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -4,6 +4,12 @@ inputs:
   version:
     description: version
     required: true
+  user_id:
+    description: user id
+    required: false
+  group_id:
+    description: group id
+    required: false
   tags:
     description: image tags
     required: true
@@ -17,6 +23,8 @@ runs:
   - name: Build and push image to docker.io
     env:
       NGINX_VER: ${{ inputs.version }}
+      WODBY_USER_ID: ${{ inputs.user_id }}
+      WODBY_GROUP_ID: ${{ inputs.group_id }}
       TAGS: ${{ inputs.tags }}
       PLATFORM: ${{ inputs.platform }}
       DOCKER_REGISTRY: docker.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM wodby/alpine:${BASE_IMAGE_TAG}
 
 ARG NGINX_VER
 
+ARG WODBY_USER_ID=1000
+ARG WODBY_GROUP_ID=1000
+
 ENV NGINX_VER="${NGINX_VER}" \
     APP_ROOT="/var/www/html" \
     FILES_DIR="/mnt/files" \
@@ -19,8 +22,8 @@ RUN set -ex; \
     addgroup -S nginx; \
     adduser -S -D -H -h /var/cache/nginx -s /sbin/nologin -G nginx nginx; \
     \
-	addgroup -g 1000 -S wodby; \
-	adduser -u 1000 -D -S -s /bin/bash -G wodby wodby; \
+	addgroup -g "${WODBY_GROUP_ID}" -S wodby; \
+	adduser -u "${WODBY_USER_ID}" -D -S -s /bin/bash -G wodby wodby; \
 	sed -i '/^wodby/s/!/*/' /etc/shadow; \
 	echo "PS1='\w\$ '" >> /home/wodby/.bashrc; \
     \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ ALPINE_VER ?= 3.13
 
 PLATFORM ?= linux/amd64
 
+ifeq ($(WODBY_USER_ID),)
+    WODBY_USER_ID := 1000
+endif
+
+ifeq ($(WODBY_GROUP_ID),)
+    WODBY_GROUP_ID := 1000
+endif
+
 ifeq ($(BASE_IMAGE_STABILITY_TAG),)
     BASE_IMAGE_TAG := $(ALPINE_VER)
 else
@@ -32,7 +40,9 @@ default: build
 build:
 	docker build -t $(REPO):$(TAG) \
         --build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
-	    --build-arg NGINX_VER=$(NGINX_VER) ./
+	    --build-arg NGINX_VER=$(NGINX_VER) \
+		--build-arg WODBY_GROUP_ID=$(WODBY_GROUP_ID) \
+		--build-arg WODBY_USER_ID=$(WODBY_USER_ID) ./
 
 # --load  doesn't work with multiple platforms https://github.com/docker/buildx/issues/59
 # we need to save cache to run tests first.
@@ -40,6 +50,8 @@ buildx-build-amd64:
 	docker buildx build --platform linux/amd64 \
 		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 		--build-arg NGINX_VER=$(NGINX_VER) \
+		--build-arg WODBY_GROUP_ID=$(WODBY_GROUP_ID) \
+		--build-arg WODBY_USER_ID=$(WODBY_USER_ID) \
 		--load \
 		-t $(REPO):$(TAG) ./
 
@@ -47,12 +59,16 @@ buildx-build:
 	docker buildx build --platform $(PLATFORM) \
 		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 		--build-arg NGINX_VER=$(NGINX_VER) \
+		--build-arg WODBY_GROUP_ID=$(WODBY_GROUP_ID) \
+		--build-arg WODBY_USER_ID=$(WODBY_USER_ID) \
 		-t $(REPO):$(TAG) ./
 
 buildx-push:
 	docker buildx build --platform $(PLATFORM) \
 		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 		--build-arg NGINX_VER=$(NGINX_VER) \
+		--build-arg WODBY_GROUP_ID=$(WODBY_GROUP_ID) \
+		--build-arg WODBY_USER_ID=$(WODBY_USER_ID) \
 		--push -t $(REPO):$(TAG) ./
 
 test:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - [Docker images](#docker-images)
 - [Environment variables](#environment-variables)
+- [Build arguments](#build-arguments)
 - [Nginx modules](#nginx-modules)
     - [ModSecurity]
 - [Default behaviour](#default-behavior)    
@@ -141,6 +142,13 @@ css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg|mp4|svgz|ogg|ogv
 ```
 
 Some environment variables can be overridden or added per [preset](#virtual-hosts-presets). 
+
+## Build arguments
+
+| Argument         | Default value |
+| ---------------- | ------------- |
+| `WODBY_GROUP_ID` | `1000`        |
+| `WODBY_USER_ID`  | `1000`        |
 
 ## Nginx modules
 


### PR DESCRIPTION
These arguments are already available in other wodby images. Such as the [ruby](https://github.com/wodby/ruby/blob/master/Dockerfile#L7) image.