### PR TITLE
Metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,9 @@ RUN set -ex; \
     url="https://github.com/masterzen/nginx-upload-progress-module/archive/v${nginx_up_ver}.tar.gz"; \
     wget -qO- "${url}" | tar xz --strip-components=1 -C /tmp/ngx_http_uploadprogress_module; \
     \
+    # Get VTS module \
+    git clone https://github.com/vozlt/nginx-module-vts.git /tmp/nginx_module_vts; \
+    \
     # Download nginx.
     curl -fSL "https://nginx.org/download/nginx-${NGINX_VER}.tar.gz" -o /tmp/nginx.tar.gz; \
     curl -fSL "https://nginx.org/download/nginx-${NGINX_VER}.tar.gz.asc"  -o /tmp/nginx.tar.gz.asc; \
@@ -161,6 +164,7 @@ RUN set -ex; \
         --with-threads \
         --add-module=/tmp/ngx_http_uploadprogress_module \
         --add-module=/tmp/ngx_brotli \
+        --add-module=/tmp/nginx_module_vts \
         --add-dynamic-module=/tmp/ngx_http_modsecurity_module; \
     \
     make -j$(getconf _NPROCESSORS_ONLN); \

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ All images built for `linux/amd64` and `linux/arm64`
 | `NGINX_KEEPALIVE_TIMEOUT`                            | `75s`                       |                                     |
 | `NGINX_LARGE_CLIENT_HEADER_BUFFERS`                  | `8 16k`                     |                                     |
 | `NGINX_LOG_FORMAT_OVERRIDE`                          |                             |                                     |
+| `NGINX_METRICS_ENABLED`                              | `off`                       |                                     |
+| `NGINX_METRICS_FORMAT`                               | `html`                      | <json|html|jsonp|prometheus>        |
+| `NGINX_METRICS_ALLOW_FROM`                           |                             |                                     |
 | `NGINX_MODSECURITY_ENABLED`                          |                             | See [ModSecurity]                   |
 | `NGINX_MODSECURITY_INBOUND_ANOMALY_SCORE_THRESHOLD`  | `7`                         |                                     |
 | `NGINX_MODSECURITY_OUTBOUND_ANOMALY_SCORE_THRESHOLD` | `7`                         |                                     |
@@ -175,6 +178,7 @@ Some environment variables can be overridden or added per [preset](#virtual-host
 | [http_v2]             |                   |         |
 | [http_xslt]           |                   | ✓       |
 | [mail_ssl]            |                   |         |
+| [nginx_vts]           |                   |         |
 | [stream_realip]       |                   |         |
 | [stream_ssl]          |                   |         |
 | [stream_ssl_preread]  |                   |         |
@@ -199,7 +203,7 @@ Applied to all presets by default, can be disabled via `$NGINX_VHOST_NO_DEFAULTS
 - `/humans.txt` allowed
 - `/favicon.ico` allowed
 - `.flv`, `.m4a`, `.mp4`, `.mov` locations supported and handled with appropriate modules
--  `/.healthz` location supported, requests not shown in access log
+- `/.healthz` location supported, requests not shown in access log
 
 ## Customization
 
@@ -213,6 +217,9 @@ Applied to all presets by default, can be disabled via `$NGINX_VHOST_NO_DEFAULTS
 - Add extra locations via `$NGINX_SERVER_EXTRA_CONF_FILEPATH=/filepath/to/nginx-locations.conf`, the file will be included at the end of default rules (`server` context)
 - Completely override include of the virtual host config by overriding `NGINX_CONF_INCLUDE`, it will be included in `nginx.conf`
 - Define [custom preset](#custom-preset)
+- Status page `/.statusz` can be enabled via `$NGINX_STATUS_ENABLED`, requests not shown in access log
+- Metrics page `/.metricsz` can be enabled via `$NGINX_METRICS_ENABLED`, requests not shown in access log
+- Metrics page format can be customized via `$NGINX_METRICS_FORMAT`, supports json, html, jsonp and prometheus
 
 ## Virtual hosts presets
 
@@ -352,9 +359,9 @@ default params values:
 [ModSecurity Library]: https://modsecurity.org/
 [ModSecurity Nginx module]: https://github.com/SpiderLabs/ModSecurity-nginx
 [ModSecurity]: #modsecurity
+[nginx_vts]: https://github.com/vozlt/nginx-module-vts
 [OWASP CRS]: https://modsecurity.org/crs/
 [WordPress]: #wordpress
 [stream_realip]: http://nginx.org/en/docs/stream/ngx_stream_realip_module.html
 [stream_ssl]: http://nginx.org/en/docs/stream/ngx_stream_ssl_module.html
 [stream_ssl_preread]: http://nginx.org/en/docs/stream/ngx_stream_ssl_preread_module.html
-

--- a/templates/includes/defaults.conf.tmpl
+++ b/templates/includes/defaults.conf.tmpl
@@ -60,6 +60,18 @@ location = /.statusz {
 }
 {{ end }}
 
+{{ if getenv "NGINX_METRICS_ENABLED" }}
+location = /.metricsz {
+    vhost_traffic_status_display;
+    vhost_traffic_status_display_format {{ getenv "NGINX_METRICS_FORMAT" "html" }};
+    allow 127.0.0.1;
+    {{ if getenv "NGINX_METRICS_ALLOW_FROM" }}
+    allow {{ getenv "NGINX_METRICS_ALLOW_FROM" }};
+    {{ end }}
+    deny all;
+}
+{{ end }}
+
 location ^~ /.well-known/ {
     allow all;
 }

--- a/templates/nginx.conf.tmpl
+++ b/templates/nginx.conf.tmpl
@@ -12,6 +12,10 @@ events {
 }
 
 http {
+    {{ if getenv "NGINX_METRICS_ENABLED" }}
+    vhost_traffic_status_zone;
+    {{ end }}
+
     include                     /etc/nginx/mime.types;
     default_type                application/octet-stream;
 

--- a/tests/basic/docker-compose.yml
+++ b/tests/basic/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - ./tests.sh:/usr/local/bin/tests.sh
       - ./nginx_modules:/home/wodby/nginx_modules
     environment:
+      NGINX_METRICS_ENABLED: "1"
       NGINX_MODSECURITY_ENABLED: "1"
       NGINX_MODSECURITY_USE_OWASP_CRS: "1"
       NGINX_LOG_FORMAT_OVERRIDE: "$$http_x_real_ip - $$request - $$status"
+      NGINX_STATUS_ENABLED: "1"

--- a/tests/basic/nginx_modules
+++ b/tests/basic/nginx_modules
@@ -19,6 +19,7 @@ http_uploadprogress
 http_v2
 http_xslt
 mail_ssl
+nginx_vts
 stream_realip
 stream_ssl
 stream_ssl_preread

--- a/tests/basic/tests.sh
+++ b/tests/basic/tests.sh
@@ -12,6 +12,14 @@ echo -n "Checking Nginx response... "
 curl -s localhost | grep -q "It works!"
 echo "OK"
 
+echo -n "Checking Status response... "
+curl -s "localhost/.statusz" | grep -q "Active connections"
+echo "OK"
+
+echo -n "Checking Metrics response... "
+curl -s "localhost/.metricsz" | grep -q "<title>nginx vhost traffic status monitor</title>"
+echo "OK"
+
 echo -n "Checking Modsecurity XSS... "
 curl -s "localhost?test=<script>alert(42)</script>" | grep -q "403 Forbidden"
 echo "OK"


### PR DESCRIPTION
Added support for nginx vts module. (https://github.com/vozlt/nginx-module-vts) 
Allows metrics in different formats including prometheus