### PR TITLE
default map needed for reverse proxy of websocket connections

### DIFF
--- a/templates/nginx.conf.tmpl
+++ b/templates/nginx.conf.tmpl
@@ -131,5 +131,14 @@ http {
         ~^/(?<no_slash>.*)$ $no_slash;
     }
 
+    # http://nginx.org/en/docs/http/websocket.html
+    # top-level http config for websocket headers
+    # If Upgrade is defined, Connection = upgrade
+    # If Upgrade is empty, Connection = close
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
     include {{ getenv "NGINX_CONF_INCLUDE" "conf.d/*.conf" }};
 }


### PR DESCRIPTION
When doing a reverse proxy for a site with websockets, some additional 'http' configuration is needed
By providing this default generic map, the configuration can stay limited to the 'server' block but still use this 'http' variable.

Literal copy from the official documentation
http://nginx.org/en/docs/http/websocket.html

It should not have any impact on performance
http://nginx.org/en/docs/http/ngx_http_map_module.html
_Since variables are evaluated only when they are used, the mere declaration even of a large number of “map” variables does not add any extra costs to request processing._