### PR TITLE
Improve Drupal static files security

### DIFF
--- a/templates/presets/drupal9.conf.tmpl
+++ b/templates/presets/drupal9.conf.tmpl
@@ -88,7 +88,8 @@ location / {
     }
     {{ end }}
 
-    location ~* ^(?:.+\.(?:make|txt|engine|inc|info|install|module|profile|po|pot|sh|.*sql|test|theme|tpl(?:\.php)?|xtmpl)|code-style\.pl|/Entries.*|/Repository|/Root|/Tag|/Template)$ {
+    # Replica of regex from Drupals core .htaccess.
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
         return 404;
     }
 


### PR DESCRIPTION
The [current](https://git.drupalcode.org/project/drupal/-/blob/9.4.x/.htaccess#L6) Drupal `.htaccess` file contains that regex:

```apache
<FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">

```

And the current nginx config regex doesn't match it. I suggest replicating it “as is” directly from Drupal core. Maybe it's a good idea to provide an environmental variable to control it, like it done for static files.

The specific reason I propose this: because currently, it is possible to view YAML files if you know where to look or will try to find them by some tools. E.g.,: https://niklan.net/modules/custom/niklan/niklan.routing.yml  such files can contain sensible information about project, such as comments and access configuration for routes that can leads to more severe problems. This better to be hidden.