### PR TITLE
Add $NGINX_WP_NOT_FOUND_REGEX to WordPress Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ All images built for `linux/amd64` and `linux/arm64`
 | `NGINX_DRUPAL_HIDE_HEADERS`                          |                           |                                     |
 | `NGINX_DRUPAL_XMLRPC_SERVER_NAME`                    |                           | Drupal 6/7 only                     |
 | `NGINX_DRUPAL_NOT_FOUND_REGEX`                       | (see [Drupal](#drupal))   |                                     |
+| `NGINX_WP_NOT_FOUND_REGEX`                       | (see [Wordpress](#wordpress))   |                                     |
 | `NGINX_ERROR_403_URI`                                |                           |                                     |
 | `NGINX_ERROR_404_URI`                                |                           |                                     |
 | `NGINX_ERROR_LOG_LEVEL`                              | `error`                   |                                     |
@@ -187,7 +188,7 @@ Some environment variables can be overridden or added per [preset](#virtual-host
 | [stream_realip]       |                   |         |
 | [stream_ssl]          |                   |         |
 | [stream_ssl_preread]  |                   |         |
-| [vts]                 | [3c6cf41]         |         |   
+| [vts]                 | [3c6cf41]         |         |
 
 ### ModSecurity
 
@@ -321,6 +322,8 @@ Overridden default values:
       add `$NGINX_WP_GOOGLE_XML_SITEMAP=1`
     - For plugin [Yoast SEO](https://kb.yoast.com/kb/xml-sitemaps-nginx/) add `$NGINX_WP_YOAST_XML_SITEMAP=1`
 - Default value of `NGINX_HEADERS_CONTENT_SECURITY_POLICY` overridden to `frame-ancestors: 'self'`
+
+Default value of NGINX_WP_NOT_FOUND_REGEX (backspaces must be escaped) is: `.+\\.(?:txt|pot|sh|.*sql?)|(?:composer\\.(json|lock)|(package|package-lock)\\.json|yarn\\.lock)$`
 
 #### Drupal
 

--- a/templates/presets/wordpress.conf.tmpl
+++ b/templates/presets/wordpress.conf.tmpl
@@ -1,4 +1,5 @@
 {{ $static := (getenv "NGINX_STATIC_EXT_REGEX" "css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg|mp4|svgz|ogg|ogv|pdf|pptx?|zip|tgz|gz|rar|bz2|doc|xls|exe|tar|mid|midi|wav|bmp|rtf|txt|map|webp") }}
+{{ $not_found_regex := (getenv "NGINX_WP_NOT_FOUND_REGEX" ".+\\.(?:txt|pot|sh|.*sql?)|(?:composer\\.(json|lock)|(package|package-lock)\\.json|yarn\\.lock)$") }}
 
 index index.php index.html;
 
@@ -53,7 +54,7 @@ location / {
         open_file_cache_errors {{ getenv "NGINX_STATIC_OPEN_FILE_CACHE_ERRORS" "off" }};
     }
 
-    location ~* .+\.(?:txt|pot|sh|.*sql?)$ {
+    location ~* {{ $not_found_regex }} {
         return 404;
     }
 


### PR DESCRIPTION
This PR adds a variable `$NGINX_WP_NOT_FOUND_REGEX` that is similar to the `$NGINX_DRUPAL_NOT_FOUND_REGEX` found in the Drupal NGINX templates.  For the default value I copied the regex that already led to a 404 in the WordPress template and added some additional regex that will block any attempts to access composer or npm files.