### PR TITLE
Add support for Drupal 10.1 CSS/JS aggregation.

### DIFF
--- a/templates/presets/drupal10.conf.tmpl
+++ b/templates/presets/drupal10.conf.tmpl
@@ -49,7 +49,7 @@ location / {
         internal;
     }
 
-    location ~* /files/styles/ {
+    location ~* /files/(css|js|styles)/ {
         access_log {{ getenv "NGINX_STATIC_ACCESS_LOG" "off" }};
         expires {{ getenv "NGINX_STATIC_EXPIRES" "1y" }};
         try_files $uri @drupal;


### PR DESCRIPTION
https://www.drupal.org/node/2888767:

> Sites using nginx/php-fpm may need to [update their nginx.conf file](https://github.com/skpr/image-nginx/pull/16/files) to pass through the css/js path to Drupal.
> 
> Before
> 
> ```
> # Passes style generation to PHP.
> location ~ ^/sites/.*/files/styles/ {
>   try_files $uri @rewrite;
> }
> ```
> 
> After
> 
> ```
> # Passes image style and asset generation to PHP.
> location ~ ^/sites/.*/files/(css|js|styles)/ {
>   try_files $uri @rewrite;
> }
> ```

Basically, without this rewrite for CSS and JS the files most likely won't be generated after Drupal 10.1 update.