### PR TITLE
Include modsecurity config for drupal10+

### DIFF
--- a/templates/includes/modsecurity.conf.tmpl
+++ b/templates/includes/modsecurity.conf.tmpl
@@ -4,7 +4,7 @@ Include /etc/nginx/modsecurity/recommended.conf
 Include /etc/nginx/modsecurity/crs/setup.conf
 {{- end }}
 
-{{- if getenv "NGINX_VHOST_PRESET" ~ ^drupal\d+$ }}
+{{- if or (eq (getenv "NGINX_VHOST_PRESET") "drupal11") (eq (getenv "NGINX_VHOST_PRESET") "drupal10") (eq (getenv "NGINX_VHOST_PRESET") "drupal9") (eq (getenv "NGINX_VHOST_PRESET") "drupal8") (eq (getenv "NGINX_VHOST_PRESET") "drupal7") (eq (getenv "NGINX_VHOST_PRESET") "drupal6") }}
 SecAction \
  "id:900130,\
   phase:1,\

--- a/templates/includes/modsecurity.conf.tmpl
+++ b/templates/includes/modsecurity.conf.tmpl
@@ -4,7 +4,7 @@ Include /etc/nginx/modsecurity/recommended.conf
 Include /etc/nginx/modsecurity/crs/setup.conf
 {{- end }}
 
-{{- if or (eq (getenv "NGINX_VHOST_PRESET") "drupal9") (eq (getenv "NGINX_VHOST_PRESET") "drupal8") (eq (getenv "NGINX_VHOST_PRESET") "drupal7") (eq (getenv "NGINX_VHOST_PRESET") "drupal6") }}
+{{- if getenv "NGINX_VHOST_PRESET" ~ ^drupal\d+$ }}
 SecAction \
  "id:900130,\
   phase:1,\


### PR DESCRIPTION
Currently it is possible to enable modsecurity, but configs for drupal are ignored if you are using drupal 10 or higher.