### PR TITLE
Modsecurity config support for all Drupal-based presets.

### DIFF
--- a/templates/includes/modsecurity.conf.tmpl
+++ b/templates/includes/modsecurity.conf.tmpl
@@ -4,7 +4,8 @@ Include /etc/nginx/modsecurity/recommended.conf
 Include /etc/nginx/modsecurity/crs/setup.conf
 {{- end }}
 
-{{- if or (eq (getenv "NGINX_VHOST_PRESET") "drupal11") (eq (getenv "NGINX_VHOST_PRESET") "drupal10") (eq (getenv "NGINX_VHOST_PRESET") "drupal9") (eq (getenv "NGINX_VHOST_PRESET") "drupal8") (eq (getenv "NGINX_VHOST_PRESET") "drupal7") (eq (getenv "NGINX_VHOST_PRESET") "drupal6") }}
+{{/* Pick up all Drupal-based presets that start with 'drupal'. */}}
+{{- if eq (printf "%.6s" (getenv "NGINX_VHOST_PRESET")) "drupal" }}
 SecAction \
  "id:900130,\
   phase:1,\


### PR DESCRIPTION
The majority of the bash script within the codebase does a [prefix check for drupal support](https://github.com/wodby/nginx/blob/8b2d0d4/docker-entrypoint.sh#L40), so it makes sense to do so here as well to keep the behaviour consistent when using custom drupal-based presets.

This should also reduce code-maintenance for future Drupal releases.

The gotmpl script used doesn't have `startswith` or `regex` support, so doing the comparison by printing only the first 6 characters and comparing that way.