### PR TITLE
Avoid setting duplicate security headers when using Drupal

### DIFF
--- a/templates/includes/defaults.conf.tmpl
+++ b/templates/includes/defaults.conf.tmpl
@@ -6,8 +6,11 @@ add_header Cache-Control "no-store, no-cache, must-revalicate, post-check=0 pre-
 
 {{- if not (getenv "NGINX_NO_DEFAULT_HEADERS") }}
 add_header  X-XSS-Protection '1; mode=block';
+{{/* the next two headers are being set by drupal already */}}
+{{- if ne (printf "%.6s" (getenv "NGINX_VHOST_PRESET")) "drupal" }}
 add_header  X-Frame-Options SAMEORIGIN;
 add_header  X-Content-Type-Options nosniff;
+{{- end }}
 add_header  Content-Security-Policy "{{ getenv "NGINX_HEADERS_CONTENT_SECURITY_POLICY" "frame-ancestors 'none'" }}";
 {{- end }}
 


### PR DESCRIPTION
Out of the four security headers set in `defaults.conf` two are also being set by Drupal, leading to duplicate headers and possible issues in the browser.

We should thus avoid setting these headers when one of the "drupal" presets is in use.